### PR TITLE
fix: error: passing HyperRectangle as 'this' argument discards qualif…

### DIFF
--- a/holesindata/hyperrectangle.cpp
+++ b/holesindata/hyperrectangle.cpp
@@ -117,7 +117,7 @@ bool operator== (const HyperRectangle &p1, const HyperRectangle &p2){
 		return *this->points.at(2).points.begin();	
 	}
 
-	double HyperRectangle::getSize(){
+	double HyperRectangle::getSize() const {
 		double end=*(--points.at(0).points.end());
 		double size=end - *points.at(0).points.begin();
 		for(int i=1;i<D;i++){

--- a/holesindata/hyperrectangle.h
+++ b/holesindata/hyperrectangle.h
@@ -38,7 +38,7 @@ public:
 	double gety();
 	double getz();
 
-	double getSize();
+	double getSize() const;
 	int containedIn( double pt[]);
 
 	void insertBoundingPoint(double pt[]);


### PR DESCRIPTION
This fixes a compilation error.

Details are explained in this StackOverflow [post](https://stackoverflow.com/questions/5973427/error-passing-xxx-as-this-argument-of-xxx-discards-qualifiers).

